### PR TITLE
PR to change height for dark variant of USelectPicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicef/material-ui",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "UNICEF theme and components of material-ui for react",
   "main": "index.js",
   "files": [

--- a/src/components/USelectPicker/USelectPicker.js
+++ b/src/components/USelectPicker/USelectPicker.js
@@ -119,6 +119,7 @@ export default function USelectPicker(props) {
   const selectStyles = {
     input: base => ({
       ...base,
+      height: iconVariant === ICON_VARIANTS.dark ? theme.spacing(4) : 'inherit', // if dark variant, then match height with material ui controls
       color: theme.palette.text.primary,
       '& input': {
         font: 'inherit',


### PR DESCRIPTION
When using dark icon variant in USelectPicker, the height of the control changes. This fix resolves that problem