### PR TITLE
PR to add matchRegexpCaseInSensitive rule to ValidatorForm

### DIFF
--- a/example/src/components/FormValidator.js
+++ b/example/src/components/FormValidator.js
@@ -78,6 +78,7 @@ export default function FormValidator() {
   const [values, setValues] = useState({
     currency: '',
     email: 'test@test.com',
+    regex: '',
     password: 'testinghere',
     positiveInteger: 1,
     currencyField: 1000.55,
@@ -323,6 +324,19 @@ export default function FormValidator() {
               variant="outlined"
               validators={['required', 'isSafeText']}
               value={values.safeText}
+            />
+          </Grid>
+          <Grid item xs={12} lg={3} xl={2}>
+            <UTextField
+              label="Custom regex(no script)"
+              onChange={handleValue}
+              className={classes.margin}
+              name="regex"
+              variant="outlined"
+              validators={[
+                'matchRegexpCaseInSensitive:^(?!.*<script\\b[^>]*>.*<\\/script\\s*>).*$',
+              ]}
+              value={values.regex}
             />
           </Grid>
           <Grid item xs={12} lg={3} xl={2}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicef/material-ui",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "UNICEF theme and components of material-ui for react",
   "main": "index.js",
   "files": [

--- a/src/components/UValidatorForm/UValidatorForm.js
+++ b/src/components/UValidatorForm/UValidatorForm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import {
   isAlphanumericText,
   isPhoneNumberText,
+  isRegexCaseInSensitive,
   isSafeText,
   isUrlText,
 } from '../../utils'
@@ -53,6 +54,13 @@ function ForwardRefForm(props, ref) {
   ValidatorForm.addValidationRule('isAlphanumeric', value => {
     return isAlphanumericText(value)
   })
+
+  ValidatorForm.addValidationRule(
+    'matchRegexpCaseInSensitive',
+    (value, regexStr) => {
+      return isRegexCaseInSensitive(value, regexStr)
+    }
+  )
 
   return <ValidatorForm {...props} ref={ref} />
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,6 +4,7 @@ import {
   isSafeText,
   isAlphanumericText,
   isUrlText,
+  isRegexCaseInSensitive,
 } from './validationRules'
 
 export {
@@ -13,4 +14,5 @@ export {
   isSafeText,
   isAlphanumericText,
   isUrlText,
+  isRegexCaseInSensitive,
 }

--- a/src/utils/validationRules.js
+++ b/src/utils/validationRules.js
@@ -17,6 +17,20 @@ export function isPhoneNumberText(value) {
  * @param {String} value Value text to be validated
  * @returns {Boolean} Whether the given value string contains safe text (no html tags)
  */
+export function isRegexCaseInSensitive(value, regexRule) {
+  const valueToTest = value || ''
+  const regexStr = regexRule
+  if (!regexStr) return true // if no regex, then accept any text
+
+  const regex = new RegExp(regexStr, 'i')
+  return regex.test(valueToTest)
+}
+
+/**
+ *
+ * @param {String} value Value text to be validated
+ * @returns {Boolean} Whether the given value string contains safe text (no html tags)
+ */
 export function isSafeText(value) {
   const valueToTest = value || ''
   let htmlRegexp = new RegExp(/<\/?[a-z][\s\S]*>/i)


### PR DESCRIPTION
ValidatorForm already has a validator for regex, but it does not work for [insensitive casing](https://github.com/NewOldMax/react-material-ui-form-validator/issues/50). Therefore, `matchRegexpCaseInSensitive` is added to cover those scenarios